### PR TITLE
pre-fill config with existing inputs, allow disabling Double Press feature

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Serpentiel/betterglobekey/internal/pkg/assets"
 	"github.com/Serpentiel/betterglobekey/internal/pkg/eventlistener"
+	"github.com/Serpentiel/betterglobekey/pkg/inputsource"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -76,6 +77,11 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 
 			if err = viper.ReadInConfig(); err != nil {
 				logger.Fatalw("failed to read config", zap.Error(err))
+			}
+
+			viper.Set("input_sources.primary", inputsource.All())
+			if err = viper.WriteConfig(); err != nil {
+				logger.Fatalw("failed to write config", zap.Error(err))
 			}
 		}
 	}

--- a/internal/pkg/assets/.betterglobekey.example.yaml
+++ b/internal/pkg/assets/.betterglobekey.example.yaml
@@ -7,11 +7,8 @@ double_press:
 input_sources:
   # Primary input sources
   # This is used when the Globe key has been pressed once
-  primary:
-    - com.apple.keylayout.US
-    - com.apple.keylayout.Russian
+  primary: []
 
   # Additional input sources
   # This is used when the Globe key has been double pressed
-  additional:
-    - com.apple.keylayout.Finnish
+  additional: []

--- a/internal/pkg/eventhandler/eventhandler.go
+++ b/internal/pkg/eventhandler/eventhandler.go
@@ -91,7 +91,7 @@ func (h *fnKeyHandler) setInputSource(inputSource string) {
 // KeyUp is called when the key is released.
 func (h *fnKeyHandler) KeyUp() handlerFunc {
 	return func() {
-		{
+		if len(h.additionalInputSources) > 0 {
 			doublePressTicker := time.NewTicker(time.Duration(h.doublePressMaximumDelay) * time.Millisecond)
 
 			h.doublePressed = h.doublePressable

--- a/internal/pkg/eventhandler/eventhandler.go
+++ b/internal/pkg/eventhandler/eventhandler.go
@@ -119,7 +119,6 @@ func (h *fnKeyHandler) KeyUp() handlerFunc {
 			// TODO: This is not working as designed at the moment—this is supposed to open the original
 			//  input source popup, but implementing it requires some reverse engineering.
 			//  There is probably a function in macOS private API that can be used to open the popup.
-
 			logger.Info("globe key double pressed")
 
 			h.setInputSource(h.previousInputSource)


### PR DESCRIPTION
**About this change—what it does?**

Disables double press feature when `additional` array is empty.
Also generates a `betterglobekey.yaml` at first run with currently used keyboard inputs.

**What type of change is it?**

<!-- Please delete options that are not relevant. -->

- [x] Bug fix, i.e. non-breaking change which fixes an issue
- [x] New feature, i.e. non-breaking change which adds functionality

**Have you checked yourself twice?**

<!-- Please check all the boxes before opening the PR. -->

- [x] I have checked my code and corrected any misspellings
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My code follows the contributing guidelines of this project
